### PR TITLE
Add inventory search across dashboard tables

### DIFF
--- a/src/components/editAmount.tsx
+++ b/src/components/editAmount.tsx
@@ -45,13 +45,20 @@ const EditAmount = ({
   };
   type: "pallet" | "scrap" | "stock" | "finishedItem" | "prodFinishedItem";
 }) => {
+  const currentAmount =
+    type === "prodFinishedItem" ? (result.prodAmount ?? 0) : result.amount;
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      amount: type === "prodFinishedItem" ? result.prodAmount : result.amount,
+      amount: currentAmount,
     },
   });
   const router = useRouter();
+  const { reset } = form;
+
+  React.useEffect(() => {
+    reset({ amount: currentAmount });
+  }, [currentAmount, reset, result.id, type]);
 
   const mutatePallet = api.pallet.updateAmount.useMutation({
     onSuccess: () => {
@@ -157,9 +164,7 @@ const EditAmount = ({
   return (
     <Dialog>
       <DialogTrigger className="">
-        <span className="">
-          {type === "prodFinishedItem" ? result.prodAmount : result.amount}
-        </span>
+        <span className="">{currentAmount}</span>
       </DialogTrigger>
       <DialogContent className="max-md:min-w-full">
         <DialogHeader>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -23,6 +23,7 @@ import Breadcrumbs from "~/components/breadCrumbs";
 import { UserButton } from "@clerk/nextjs";
 import "@algolia/autocomplete-theme-classic";
 import { Suspense } from "react";
+import { Search } from "~/components/search";
 
 const Header = async () => {
   return (
@@ -105,8 +106,8 @@ const Header = async () => {
       <Suspense fallback={<div>Loading...</div>}>
         <Breadcrumbs />
       </Suspense>
-      <div className="relative ml-auto flex-1 text-muted-foreground md:grow-0">
-        <p>Search</p>
+      <div className="ml-auto flex-1 md:grow-0">
+        <Search />
       </div>
       <UserButton />
     </header>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,128 +1,116 @@
-// "use client";
-// import algoliasearch from "algoliasearch/lite";
-// import {
-//   Hits,
-//   Configure,
-//   useInstantSearch,
-//   useSearchBox,
-//   UseSearchBoxProps,
-// } from "react-instantsearch";
-// import { InstantSearchNext } from "react-instantsearch-nextjs";
+"use client";
 
-// import { Hit } from "./hit";
-// import { Input } from "./ui/input";
-// import { PlaceholdersAndVanishInput } from "./inputAnimation";
-// import React, { useState, useRef } from "react";
-// import { Card, CardContent } from "./ui/card";
-// import { Table, TableBody } from "./ui/table";
-// const searchClient = algoliasearch(
-//   "KH60NZV6Q6",
-//   "2c44fcbda3712ff9731a7d9037c95f32",
-// );
+import { Search as SearchIcon } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 
-// function SearchBox(props: UseSearchBoxProps) {
-//   const { query, refine } = useSearchBox(props);
-//   const { status } = useInstantSearch();
-//   const [inputValue, setInputValue] = useState(query);
-//   const inputRef = useRef<HTMLInputElement>(null);
+import { Badge } from "~/components/ui/badge";
+import { Input } from "~/components/ui/input";
+import { api } from "~/trpc/react";
 
-//   const isSearchStalled = status === "stalled";
+const MIN_SEARCH_LENGTH = 2;
 
-//   function setQuery(newQuery: string) {
-//     setInputValue(newQuery);
+const typeLabel = {
+  stock: "Stock",
+  scrap: "Scrap",
+  pallet: "Pallet",
+} as const;
 
-//     refine(newQuery);
-//   }
+export function Search() {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
 
-//   return (
-//     <div>
-//       <form
-//         action=""
-//         role="search"
-//         noValidate
-//         onSubmit={(event) => {
-//           event.preventDefault();
-//           event.stopPropagation();
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedQuery(query.trim());
+    }, 250);
 
-//           if (inputRef.current) {
-//             inputRef.current.blur();
-//           }
-//         }}
-//         onReset={(event) => {
-//           event.preventDefault();
-//           event.stopPropagation();
+    return () => window.clearTimeout(timeout);
+  }, [query]);
 
-//           setQuery("");
-//           // this is causing several errors in console when navigating from login page
+  const shouldSearch = debouncedQuery.length >= MIN_SEARCH_LENGTH;
+  const results = api.all.search.useQuery(
+    { query: debouncedQuery },
+    {
+      enabled: shouldSearch,
+      staleTime: 60_000,
+    },
+  );
 
-//           if (inputRef.current) {
-//             inputRef.current.focus();
-//           }
-//         }}
-//       >
-//         <Input
-//           ref={inputRef}
-//           autoComplete="off"
-//           autoCorrect="off"
-//           autoCapitalize="off"
-//           placeholder="Search..."
-//           className="w-full rounded-lg bg-background pl-8 md:w-[200px] lg:w-[320px]"
-//           spellCheck={false}
-//           maxLength={512}
-//           type="search"
-//           value={inputValue}
-//           onChange={(event) => {
-//             setQuery(event.currentTarget.value);
-//           }}
-//         />
-//         <span hidden={!isSearchStalled}>Searching…</span>
-//       </form>
-//     </div>
-//   );
-// }
-// function EmptyQueryBoundary({
-//   children,
-//   fallback,
-// }: {
-//   children: React.ReactNode;
-//   fallback: React.ReactNode;
-// }) {
-//   const { indexUiState } = useInstantSearch();
+  const showResults = isOpen && query.trim().length >= MIN_SEARCH_LENGTH;
 
-//   if (!indexUiState.query) {
-//     return (
-//       <>
-//         {fallback}
-//         <div hidden>{children}</div>
-//       </>
-//     );
-//   }
+  return (
+    <div className="relative w-full md:w-[320px]">
+      <form
+        role="search"
+        onSubmit={(event) => {
+          event.preventDefault();
+        }}
+      >
+        <SearchIcon className="pointer-events-none absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          aria-label="Search inventory"
+          autoComplete="off"
+          className="w-full rounded-lg bg-background pl-8"
+          maxLength={100}
+          onChange={(event) => {
+            setQuery(event.currentTarget.value);
+            setIsOpen(true);
+          }}
+          onFocus={() => setIsOpen(true)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") setIsOpen(false);
+          }}
+          placeholder="Search stock, scrap, pallets..."
+          spellCheck={false}
+          type="search"
+          value={query}
+        />
+      </form>
 
-//   return children;
-// }
+      {showResults ? (
+        <div className="absolute right-0 top-12 z-50 w-full overflow-hidden rounded-md border bg-card text-card-foreground shadow-md">
+          {results.isLoading ? (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              Searching...
+            </p>
+          ) : null}
 
-// export function Search() {
-//   return (
-//     <InstantSearchNext
-//       indexName="rlinventory"
-//       searchClient={searchClient}
-//       future={{ preserveSharedStateOnUnmount: true }}
-//       insights={true}
-//     >
-//       <div className="relative">
-//         <SearchBox />
-//         <div className="absolute w-full border bg-card">
-//           <EmptyQueryBoundary fallback={null}>
-//             <Hits hitComponent={Hit} />
-//           </EmptyQueryBoundary>
-//         </div>
-//       </div>
+          {results.isError ? (
+            <p className="px-3 py-2 text-sm text-destructive">
+              Search is unavailable.
+            </p>
+          ) : null}
 
-//       <Configure
-//         hitsPerPage={3}
-//         attributesToHighlight={["width", "length"]}
-//         attributesToSnippet={["description"]}
-//       />
-//     </InstantSearchNext>
-//   );
-// }
+          {results.data?.length === 0 ? (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              No inventory matches found.
+            </p>
+          ) : null}
+
+          {results.data?.map((result) => (
+            <Link
+              className="block border-b px-3 py-2 text-sm transition-colors last:border-b-0 hover:bg-muted"
+              href={result.href}
+              key={`${result.type}-${result.id}`}
+              onClick={() => setIsOpen(false)}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium leading-none">{result.label}</p>
+                  {result.description ? (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {result.description}
+                    </p>
+                  ) : null}
+                </div>
+                <Badge variant="outline">{typeLabel[result.type]}</Badge>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/server/api/routers/all.ts
+++ b/src/server/api/routers/all.ts
@@ -1,12 +1,27 @@
-import algoliasearch from "algoliasearch";
-import { eq } from "drizzle-orm";
 import { z } from "zod";
 
-import {
-  createTRPCRouter,
-  protectedProcedure,
-  publicProcedure,
-} from "~/server/api/trpc";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+
+const SEARCH_RESULT_LIMIT = 12;
+
+type SearchResult = {
+  id: number;
+  type: "stock" | "scrap" | "pallet";
+  label: string;
+  description: string;
+  href: string;
+  dateModified: string | null;
+  searchText: string;
+};
+
+const normalize = (value: unknown) => {
+  if (Array.isArray(value)) return value.join(" ");
+  if (typeof value === "boolean") return value ? "yes true" : "no false";
+  return String(value ?? "");
+};
+
+const toSearchText = (values: unknown[]) =>
+  values.map(normalize).join(" ").toLowerCase();
 
 export const allRouter = createTRPCRouter({
   getTotals: protectedProcedure.query(async ({ ctx }) => {
@@ -19,11 +34,12 @@ export const allRouter = createTRPCRouter({
       pallets: pallets.length,
     };
   }),
-  queryEverything: publicProcedure.query(async ({ ctx }) => {
+  queryEverything: protectedProcedure.query(async ({ ctx }) => {
     const stock = await ctx.db.query.stockSheet.findMany();
     const scrap = await ctx.db.query.scrapMaterial.findMany();
     const pallets = await ctx.db.query.pallets.findMany();
     const finishedItems = await ctx.db.query.finishedItems.findMany();
+
     return [
       { type: "stock", ...stock },
       { type: "scrap", ...scrap },
@@ -31,4 +47,124 @@ export const allRouter = createTRPCRouter({
       { type: "finishedItems", ...finishedItems },
     ];
   }),
+  search: protectedProcedure
+    .input(
+      z.object({
+        query: z.string().trim().min(1).max(100),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const query = input.query.toLowerCase();
+      const [stock, scrap, pallets] = await Promise.all([
+        ctx.db.query.stockSheet.findMany(),
+        ctx.db.query.scrapMaterial.findMany(),
+        ctx.db.query.pallets.findMany(),
+      ]);
+
+      const stockResults: SearchResult[] = stock.map((item) => {
+        const dimensions = `${item.width}x${item.length}`;
+        const flute = `${item.strength ?? ""}${item.flute ?? ""}`;
+
+        return {
+          id: item.id,
+          type: "stock",
+          label:
+            item.descriptionAsTitle && item.description
+              ? item.description
+              : `${dimensions} Stock Sheet`,
+          description: [flute, item.color, item.CompanyUsedFor?.[0]]
+            .filter(Boolean)
+            .join(" | "),
+          href: `/dashboard/stock/${item.id}`,
+          dateModified: item.dateModified,
+          searchText: toSearchText([
+            "stock",
+            "stock sheet",
+            dimensions,
+            item.width,
+            item.length,
+            flute,
+            item.flute,
+            item.color,
+            item.CompanyUsedFor,
+            item.description,
+            item.sageId,
+            item.amount,
+          ]),
+        };
+      });
+
+      const scrapResults: SearchResult[] = scrap.map((item) => {
+        const dimensions = `${item.width}x${item.length}`;
+        const flute = `${item.strength ?? ""}${item.flute ?? ""}`;
+
+        return {
+          id: item.id,
+          type: "scrap",
+          label: `${dimensions} Scrap Material`,
+          description: [flute, item.color, item.CompanyUsedFor?.[0]]
+            .filter(Boolean)
+            .join(" | "),
+          href: `/dashboard/scrap/${item.id}`,
+          dateModified: item.dateModified,
+          searchText: toSearchText([
+            "scrap",
+            "scrap material",
+            dimensions,
+            item.width,
+            item.length,
+            flute,
+            item.flute,
+            item.color,
+            item.CompanyUsedFor,
+            item.notes,
+            item.sageId,
+            item.amount,
+            item.scored,
+            item.scoredAt,
+          ]),
+        };
+      });
+
+      const palletResults: SearchResult[] = pallets.map((item) => {
+        const dimensions = `${item.width}x${item.length}`;
+
+        return {
+          id: item.id,
+          type: "pallet",
+          label: `${dimensions} ${item.block ? "Block " : ""}Pallet`,
+          description: [
+            item.used ? "Used" : "New",
+            item.heatTreated ? "Heat Treated" : null,
+          ]
+            .filter(Boolean)
+            .join(" | "),
+          href: "/dashboard/pallets",
+          dateModified: item.dateModified,
+          searchText: toSearchText([
+            "pallet",
+            "pallets",
+            dimensions,
+            item.width,
+            item.length,
+            item.description,
+            item.sageId,
+            item.amount,
+            item.block ? "block" : "standard",
+            item.used ? "used" : "new",
+            item.heatTreated ? "heat treated" : "not heat treated",
+          ]),
+        };
+      });
+
+      return [...stockResults, ...scrapResults, ...palletResults]
+        .filter((item) => item.searchText.includes(query))
+        .sort(
+          (a, b) =>
+            new Date(b.dateModified ?? 0).getTime() -
+            new Date(a.dateModified ?? 0).getTime(),
+        )
+        .slice(0, SEARCH_RESULT_LIMIT)
+        .map(({ searchText: _searchText, ...result }) => result);
+    }),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a dashboard header search bar for stock sheets, scrap material, and pallets
- Add a protected tRPC search endpoint that normalizes searchable inventory fields and returns matching results
- Preserve the existing all-inventory CSV endpoint used by exports
- Reset the edit amount form when a refreshed/reused modal receives a different item or amount

## Testing
- `SKIP_ENV_VALIDATION=1 pnpm lint` (passes; existing warnings remain)
- `SKIP_ENV_VALIDATION=1 pnpm exec tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00d302a4-5629-4a42-b87f-d359de404fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00d302a4-5629-4a42-b87f-d359de404fbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

