### PR TITLE
fix: move send email to actions menu on mobile

### DIFF
--- a/src/app/dashboard/finishedItems/page.tsx
+++ b/src/app/dashboard/finishedItems/page.tsx
@@ -238,7 +238,9 @@ const FinishedItemResults = async () => {
                             </>
                           </ViewDetailed>
                           {result.inventoryThreshold >= result.amount ? (
-                            <SendEmail item={result} />
+                            <span className="hidden md:contents">
+                              <SendEmail item={result} />
+                            </span>
                           ) : null}
                         </TableCell>
                         <TableCell>
@@ -275,6 +277,11 @@ const FinishedItemResults = async () => {
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
                               <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                              {result.inventoryThreshold >= result.amount ? (
+                                <div className="md:hidden">
+                                  <SendEmail item={result} variant="menu" />
+                                </div>
+                              ) : null}
                               <Edit id={result.id} />
                               <DeleteItem id={result.id} type="finishedItem" />
                             </DropdownMenuContent>

--- a/src/app/dashboard/pallets/page.tsx
+++ b/src/app/dashboard/pallets/page.tsx
@@ -142,9 +142,11 @@ const PalletResults = async () => {
                   width="50"
                 />
               </TableCell>
-              <TableCell className="font-medium relative">
+              <TableCell className="relative font-medium">
                 {result.width}x{result.length} {result.block ? "Block" : ""}
+                <span className="hidden md:contents">
                   <SendEmail item={result} />
+                </span>
               </TableCell>
               <TableCell>
                 <Badge variant="outline">{result.used ? "Yes" : "No"}</Badge>
@@ -170,6 +172,9 @@ const PalletResults = async () => {
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                    <div className="md:hidden">
+                      <SendEmail item={result} variant="menu" />
+                    </div>
                     <Edit id={result.id} />
                     <DeleteItem id={result.id} type="pallet" />
                   </DropdownMenuContent>

--- a/src/app/dashboard/stock/page.tsx
+++ b/src/app/dashboard/stock/page.tsx
@@ -214,7 +214,9 @@ const StockResults = async () => {
                             </>
                           </ViewDetailed>
                           {result.inventoryThreshold >= result.amount ? (
-                            <SendEmail item={result} />
+                            <span className="hidden md:contents">
+                              <SendEmail item={result} />
+                            </span>
                           ) : null}
                         </TableCell>
                         <TableCell>
@@ -250,6 +252,11 @@ const StockResults = async () => {
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
                               <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                              {result.inventoryThreshold >= result.amount ? (
+                                <div className="md:hidden">
+                                  <SendEmail item={result} variant="menu" />
+                                </div>
+                              ) : null}
                               <Edit id={result.id} />
                               <DeleteItem id={result.id} type="stock" />
                             </DropdownMenuContent>

--- a/src/components/sendEmail.tsx
+++ b/src/components/sendEmail.tsx
@@ -25,7 +25,16 @@ type PalletItemData =
 
 type ItemData = StockItemData | FinishedItemData | PalletItemData;
 
-const SendEmail = ({ item }: { item: ItemData }) => {
+const menuItemClassName =
+  "flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50";
+
+const SendEmail = ({
+  item,
+  variant = "icon",
+}: {
+  item: ItemData;
+  variant?: "icon" | "menu";
+}) => {
   const getTitle = () => {
     if ("depth" in item) {
       // Finished item
@@ -54,8 +63,10 @@ const SendEmail = ({ item }: { item: ItemData }) => {
   };
 
   return (
-    <div>
-      <Dialog>
+    <Dialog>
+      {variant === "menu" ? (
+        <DialogTrigger className={menuItemClassName}>Send Email</DialogTrigger>
+      ) : (
         <DialogTrigger asChild>
           <Button
             className="absolute bottom-0 right-0 top-0 m-auto h-8 w-8"
@@ -64,6 +75,7 @@ const SendEmail = ({ item }: { item: ItemData }) => {
             <Send className="h-4 w-4" />
           </Button>
         </DialogTrigger>
+      )}
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Request More {getTitle()}?</DialogTitle>
@@ -107,8 +119,7 @@ const SendEmail = ({ item }: { item: ItemData }) => {
             </DialogClose>
           </div>
         </DialogContent>
-      </Dialog>
-    </div>
+    </Dialog>
   );
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On small screens, the send-email icon button in the Name column overlapped item names on the stock, finished items, and pallet list pages.

- **Desktop (`md` and up):** unchanged — inline send icon in the Name column
- **Mobile (below `md`):** send email is hidden from the Name column and added to the row **Actions** (⋯) dropdown

## Changes

- Extended `SendEmail` with a `variant="menu"` option that matches existing dropdown action styling (Edit / Delete)
- Applied the mobile/desktop split on:
  - `/dashboard/stock`
  - `/dashboard/finishedItems`
  - `/dashboard/pallets`

Stock and finished items still only show send email when inventory is at or below threshold; pallets always include it in the menu on mobile.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed4e3d9d-66b3-4ad1-9f22-52f33399c32b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed4e3d9d-66b3-4ad1-9f22-52f33399c32b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

